### PR TITLE
feat(model-input): model input using time sequence

### DIFF
--- a/hamilflow/models/brownian_motion.py
+++ b/hamilflow/models/brownian_motion.py
@@ -6,6 +6,8 @@ import pandas as pd
 import scipy as sp
 from pydantic import BaseModel, Field, computed_field, field_validator
 
+from hamilflow.models.utils.typing import TypeTime
+
 
 class BrownianMotionSystem(BaseModel):
     r"""Definition of the Brownian Motion system
@@ -183,17 +185,29 @@ class BrownianMotion:
 
         return trajectory
 
-    def __call__(self, n_steps: int, seed: int = 42) -> pd.DataFrame:
-        """Simulate the coordinates of the particle
+    def generate_from(self, n_steps: int, seed: int = 42) -> pd.DataFrame:
+        """generate data from a set of interpretable params for this model
 
         :param n_steps: total number of steps to be simulated, including the inital step.
         :param seed: random generator seed for the stochastic process.
             Use it to reproduce results.
         """
+        time_steps = np.arange(0, n_steps) * self.system.delta_t
+
+        return self(t=time_steps, seed=seed)
+
+    def __call__(self, t: TypeTime, seed: int = 42) -> pd.DataFrame:
+        """Simulate the coordinates of the particle
+
+        :param t: the time sequence to be used to generate data
+        :param seed: random generator seed for the stochastic process.
+            Use it to reproduce results.
+        """
+        n_steps = len(t)
         trajectory = self._trajectory(n_new_steps=n_steps - 1, seed=seed)
 
         df = pd.DataFrame(trajectory, columns=self._axis_names)
 
-        df["t"] = np.arange(0, n_steps) * self.system.delta_t
+        df["t"] = t
 
         return df

--- a/hamilflow/models/pendulum.py
+++ b/hamilflow/models/pendulum.py
@@ -8,6 +8,8 @@ from numpy.typing import ArrayLike
 from pydantic import BaseModel, Field, computed_field
 from scipy.special import ellipj, ellipk
 
+from hamilflow.models.utils.typing import TypeTime
+
 
 class PendulumSystem(BaseModel):
     r"""The params for the pendulum.
@@ -130,11 +132,26 @@ class Pendulum:
 
         return 2 * np.arcsin(cn / dn * self._k)
 
-    def __call__(self, n_periods: int, n_samples_per_period: int) -> pd.DataFrame:
+    def generate_from(self, n_periods: int, n_samples_per_period: int) -> pd.DataFrame:
+        """generate the time sequence from more interpretable params
+
+        :param n_periods: number of periods to include
+        :param n_samples_per_period: number of samples in each period
+        :return: an array that contains all the timesteps
+        """
         time_delta = self.period / n_samples_per_period
         time_steps = np.arange(0, n_periods * n_samples_per_period) * time_delta
 
-        thetas = self.theta(time_steps)
-        us = self.u(time_steps)
+        return self(time_steps)
 
-        return pd.DataFrame(dict(t=time_steps, x=thetas, u=us))
+    def __call__(self, t: TypeTime) -> pd.DataFrame:
+        """generate the variables of the pendulum in time together with the time steps
+
+        :param t: time steps
+        :return: values of the variables
+            angle `x`, generalized coordinates `u`, and time `t`.
+        """
+        thetas = self.theta(t)
+        us = self.u(t)
+
+        return pd.DataFrame(dict(t=t, x=thetas, u=us))

--- a/hamilflow/models/utils/typing.py
+++ b/hamilflow/models/utils/typing.py
@@ -1,0 +1,5 @@
+from typing import Sequence, TypeVar
+
+from numpy.typing import ArrayLike
+
+TypeTime = TypeVar("TypeTime", Sequence[float], Sequence[int], ArrayLike)

--- a/tests/test_models/test_brownian_motion.py
+++ b/tests/test_models/test_brownian_motion.py
@@ -75,7 +75,7 @@ def test_brownian_motion(sigma, x0, expected):
     bm = BrownianMotion(system=system, initial_condition=initial_condition)
 
     pd.testing.assert_frame_equal(
-        bm(n_steps=5, seed=42),
+        bm.generate_from(n_steps=5, seed=42),
         pd.DataFrame(expected),
         check_exact=False,
         check_like=True,

--- a/tests/test_models/test_pendulum.py
+++ b/tests/test_models/test_pendulum.py
@@ -70,3 +70,9 @@ class TestPendulum:
         theta, theta_1 = p.theta(times), p.theta(arr_times_1)
 
         assert_array_almost_equal(theta, theta_1)
+
+    def test_generate_from(self, omega0: float, theta0: float) -> None:
+        p = Pendulum(omega0, theta0)
+
+        df = p.generate_from(n_periods=1, n_samples_per_period=10)
+        assert len(df) == 10


### PR DESCRIPTION
Resolves #45

Changed:
- [x] call method will now only accept time sequence

Added:
- [x] `generate_from` method to generate data from some easy to interpret parameters. This will make it easier to generate data from yaml configs.

